### PR TITLE
Feature/log version number on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Log version number on startup
   - Fix inverted constants in survey transform.
   - Change `status_code` to `status` for SDX logging
 

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+from transform import __version__
 from transform import app, settings
 import logging
 import os
@@ -6,5 +7,6 @@ import os
 if __name__ == '__main__':
     # Startup
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
+    logging.info("Current version: {}".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)

--- a/server.py
+++ b/server.py
@@ -7,6 +7,6 @@ import os
 if __name__ == '__main__':
     # Startup
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
-    logging.info("Current version: {}".format(__version__))
+    logging.info("Starting server: version='{}'".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)

--- a/transform/__init__.py
+++ b/transform/__init__.py
@@ -4,3 +4,6 @@ app = Flask(__name__)
 
 from .views import test_views  # noqa
 from .views import main  # noqa
+
+
+__version__ = "1.0.0"


### PR DESCRIPTION
This is a pull request to add functionality that logs the current version number on service startup. The `__version__` variable in `transform/__init__.py` contains the current release value, which will need to be manually updated on a new release being cut. The version is logged at INFO level.