### PR TITLE
Update version for faster build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 RUN apt-get update && apt-get install -y poppler-utils
 


### PR DESCRIPTION
## What? and Why?
Updates the image docker uses to the same one in the flask-crypto image.  Because of the way docker works, it recognises that it has a copy of this already though the flask-crypto image (which is also based on python 3.6 image) and uses the downloaded version.

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
