### PR TITLE
Move startup log to import of transform module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add startup version log
 
 ### 2.0.0 2018-01-04
   - Add /info healthcheck endpoint

--- a/server.py
+++ b/server.py
@@ -1,12 +1,8 @@
-from transform import __version__
-from transform import app, settings
-import logging
+from transform import app
 import os
 
 
 if __name__ == '__main__':
     # Startup
-    logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
-    logging.info("Starting server: version='{}'".format(__version__))
     port = int(os.getenv("PORT"))
     app.run(debug=True, host='0.0.0.0', port=port)

--- a/transform/__init__.py
+++ b/transform/__init__.py
@@ -1,9 +1,17 @@
 from flask import Flask
+import logging
+from structlog import wrap_logger
+
+from . import settings
+
+__version__ = "2.0.0"
+
+logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
+logger = wrap_logger(logging.getLogger(__name__))
+    
+logger.info("Starting Transform Cora", version=__version__)
 
 app = Flask(__name__)
 
 from .views import test_views  # noqa
 from .views import main  # noqa
-
-
-__version__ = "2.0.0"


### PR DESCRIPTION
## What? and Why?
Move the startup version log to happen on import. This means it works when run under gunicorn.
## Checklist
  - [x] CHANGELOG.md updated? (if required)
